### PR TITLE
Update the serviceKeyId to be correct

### DIFF
--- a/ironcore-config.json
+++ b/ironcore-config.json
@@ -1,5 +1,5 @@
 {
     "projectId": 2,
     "segmentId": "getting-started-react",
-    "serviceKeyId": 534
+    "serviceKeyId": 541
 }


### PR DESCRIPTION
Our api just started using the serviceKeyId and since this one was wrong the JWTs were not validating correctly.